### PR TITLE
vite-migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ Thumbs.db
 *.tar
 *.zip
 
+/assets/
+
+phpunit-log.xml
+phpunit-testdox.txt
+
 # -------------------------
 # BEGIN Whitelisted Files
 # -------------------------
@@ -53,3 +58,4 @@ Thumbs.db
 # track these files, if they exist
 !.gitignore
 !.editorconfig
+!/.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "biomejs.biome",
+        "ms-azuretools.vscode-docker",
+        "xdebug.php-debug",
+        "bmewburn.vscode-intelephense-client",
+        "devsense.composer-php-vscode",
+        "jkillian.custom-local-formatters"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit"
+    },
+    "customLocalFormatters.formatters": [
+        {
+            "command": "vendor/bin/mago format --stdin-input",
+            "languages": ["php"]
+        }
+    ],
+    "[php]": {
+        "editor.defaultFormatter": "jkillian.custom-local-formatters"
+    }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+	"linter": {
+		"rules": {
+			"complexity": {
+				"noStaticOnlyClass": "off"
+			},
+			"style": {
+				"noNonNullAssertion": "off"
+			}
+		}
+	},
+	"formatter": {
+		"lineWidth": 120
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single"
+		}
+	},
+	"assist": {
+        "enabled": true,
+        "actions": {
+            "source": {
+                "organizeImports": "on"
+            }
+        }
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once './vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,28 @@
             "email": "kristoffer.svanmark@lexiconitkonsult.se"
         }
     ],
-    "require": {},
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test:coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit",
+        "lint": "vendor/bin/mago lint",
+        "fix": "vendor/bin/mago lint --format-after-fix --fix",
+        "format": "vendor/bin/mago fmt"
+    },
     "autoload": {
         "psr-4": {
             "SearchNotices\\": "source/php/"
+        }
+    },
+    "suggest": {
+        "helsingborg-stad/municipio": "^6.0.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5",
+        "carthage-software/mago": "^1.8"
+    },
+    "config": {
+        "allow-plugins": {
+            "carthage-software/mago": true
         }
     }
 }

--- a/mago.toml
+++ b/mago.toml
@@ -1,0 +1,44 @@
+# Welcome to Mago!
+# For full documentation, see https://mago.carthage.software/tools/overview
+php-version = "8.2.0"
+
+[source]
+paths = ["source/php/"]
+includes = ["vendor"]
+excludes = []
+
+[formatter]
+print-width = 999
+tab-width = 4
+use-tabs = false
+preserve-breaking-parameter-list = true
+preserve-breaking-argument-list = true
+preserve-breaking-array-like = true
+preserve-breaking-attribute-list = true
+
+[linter]
+integrations = ["phpunit"]
+
+[linter.rules]
+ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }
+
+# IMPORTANT! 
+# Temporarily lower severity error to warning.
+# Remove when adressed
+
+no-empty = { level = "warning" }
+no-global = { level = "warning" }
+kan-defect = { level = "warning" }
+cyclomatic-complexity = { level = "warning" }
+
+# End IMPORTANT!
+
+[analyzer]
+find-unused-definitions = true
+find-unused-expressions = false
+analyze-dead-code = false
+check-throws = true
+allow-possibly-undefined-array-keys = true
+perform-heuristic-checks = true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="bootstrap.php"
+         backupGlobals="false"
+         colors="true"
+        >
+
+  <logging>
+    <junit outputFile="phpunit-log.xml"/>
+    <testdoxText outputFile="phpunit-testdox.txt"/>
+  </logging>
+
+  <testsuites>
+    <testsuite name="Unit Test Suite">
+      <directory suffix="Test.php">./source</directory>
+    </testsuite>
+  </testsuites>
+
+</phpunit>

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+
 namespace SearchNotices;
 
 class App
@@ -30,11 +33,11 @@ class App
             acf_add_options_page(array(
                 'page_title' => __('Search notices', 'search-notices'),
                 'menu_title' => __('Search notices', 'search-notices'),
-                'menu_slug'  => 'search-notices',
+                'menu_slug' => 'search-notices',
                 'parent_slug' => 'options-general.php',
                 'capability' => 'edit_posts',
-                'position'   => 500,
-                'icon_url'   => 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjM3NnB4IiBoZWlnaHQ9IjM3NnB4IiB2aWV3Qm94PSIwIDAgMzc2IDM3NiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMzkuMSAoMzE3MjApIC0gaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoIC0tPgogICAgPHRpdGxlPm5vdW5fNTAwOTQ0X2NjPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9Im5vdW5fNTAwOTQ0X2NjIiBmaWxsPSIjMDAwMDAwIj4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwIj4KICAgICAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtcGF0aCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjU3NTQ2MCwgMTIyLjQzNjUzNCkgcm90YXRlKDI2OS45OTU1NTgpIHRyYW5zbGF0ZSgtMTUwLjU3NTQ2MCwgLTEyMi40MzY1MzQpICIgeD0iMTAyLjc3NTQ2IiB5PSIxMDMuNjg2NTM0IiB3aWR0aD0iOTUuNiIgaGVpZ2h0PSIzNy41Ij48L3JlY3Q+CiAgICAgICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlLXBhdGgiIHg9IjEzMS44IiB5PSIxODgiIHdpZHRoPSIzNy41IiBoZWlnaHQ9IjM3LjUiPjwvcmVjdD4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0zNjEuOCwyOTUuNSBMMjg0LjQsMjE4LjEgQzMxMi44LDE2MS44IDMwMy42LDkxLjUgMjU2LjYsNDQuNSBDMTk4LC0xNC4xIDEwMy4xLC0xNC4xIDQ0LjUsNDQuNSBDLTE0LjEsMTAzLjEgLTE0LjEsMTk4IDQ0LjUsMjU2LjYgQzkxLjUsMzAzLjYgMTYxLjksMzEyLjggMjE4LjEsMjg0LjQgTDI5NS41LDM2MS44IEMzMTMuOCwzODAuMSAzNDMuNSwzODAuMSAzNjEuOCwzNjEuOCBDMzgwLjEsMzQzLjUgMzgwLjEsMzEzLjggMzYxLjgsMjk1LjUgTDM2MS44LDI5NS41IFogTTcxLDIzMC4xIEMyNy4xLDE4Ni4yIDI3LjEsMTE0LjkgNzEsNzEgQzExNC45LDI3LjEgMTg2LjIsMjcuMSAyMzAuMSw3MSBDMjc0LDExNC45IDI3NCwxODYuMiAyMzAuMSwyMzAuMSBDMTg2LjIsMjczLjkgMTE0LjgsMjczLjkgNzEsMjMwLjEgTDcxLDIzMC4xIFogTTMzNS4zLDMzNS4zIEMzMzEuNiwzMzkgMzI1LjcsMzM5IDMyMi4xLDMzNS4zIEwyNDkuNywyNjIuOSBDMjUyLDI2MC44IDI1NC40LDI1OC44IDI1Ni43LDI1Ni42IEMyNTguOSwyNTQuNCAyNjAuOSwyNTIgMjYzLDI0OS42IEwzMzUuNCwzMjIgQzMzOC45LDMyNS43IDMzOC45LDMzMS42IDMzNS4zLDMzNS4zIEwzMzUuMywzMzUuMyBaIiBpZD0iU2hhcGUiPjwvcGF0aD4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+'
+                'position' => 500,
+                'icon_url' => 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjM3NnB4IiBoZWlnaHQ9IjM3NnB4IiB2aWV3Qm94PSIwIDAgMzc2IDM3NiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMzkuMSAoMzE3MjApIC0gaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoIC0tPgogICAgPHRpdGxlPm5vdW5fNTAwOTQ0X2NjPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9Im5vdW5fNTAwOTQ0X2NjIiBmaWxsPSIjMDAwMDAwIj4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwIj4KICAgICAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtcGF0aCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjU3NTQ2MCwgMTIyLjQzNjUzNCkgcm90YXRlKDI2OS45OTU1NTgpIHRyYW5zbGF0ZSgtMTUwLjU3NTQ2MCwgLTEyMi40MzY1MzQpICIgeD0iMTAyLjc3NTQ2IiB5PSIxMDMuNjg2NTM0IiB3aWR0aD0iOTUuNiIgaGVpZ2h0PSIzNy41Ij48L3JlY3Q+CiAgICAgICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlLXBhdGgiIHg9IjEzMS44IiB5PSIxODgiIHdpZHRoPSIzNy41IiBoZWlnaHQ9IjM3LjUiPjwvcmVjdD4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0zNjEuOCwyOTUuNSBMMjg0LjQsMjE4LjEgQzMxMi44LDE2MS44IDMwMy42LDkxLjUgMjU2LjYsNDQuNSBDMTk4LC0xNC4xIDEwMy4xLC0xNC4xIDQ0LjUsNDQuNSBDLTE0LjEsMTAzLjEgLTE0LjEsMTk4IDQ0LjUsMjU2LjYgQzkxLjUsMzAzLjYgMTYxLjksMzEyLjggMjE4LjEsMjg0LjQgTDI5NS41LDM2MS44IEMzMTMuOCwzODAuMSAzNDMuNSwzODAuMSAzNjEuOCwzNjEuOCBDMzgwLjEsMzQzLjUgMzgwLjEsMzEzLjggMzYxLjgsMjk1LjUgTDM2MS44LDI5NS41IFogTTcxLDIzMC4xIEMyNy4xLDE4Ni4yIDI3LjEsMTE0LjkgNzEsNzEgQzExNC45LDI3LjEgMTg2LjIsMjcuMSAyMzAuMSw3MSBDMjc0LDExNC45IDI3NCwxODYuMiAyMzAuMSwyMzAuMSBDMTg2LjIsMjczLjkgMTE0LjgsMjczLjkgNzEsMjMwLjEgTDcxLDIzMC4xIFogTTMzNS4zLDMzNS4zIEMzMzEuNiwzMzkgMzI1LjcsMzM5IDMyMi4xLDMzNS4zIEwyNDkuNywyNjIuOSBDMjUyLDI2MC44IDI1NC40LDI1OC44IDI1Ni43LDI1Ni42IEMyNTguOSwyNTQuNCAyNjAuOSwyNTIgMjYzLDI0OS42IEwzMzUuNCwzMjIgQzMzOC45LDMyNS43IDMzOC45LDMzMS42IDMzNS4zLDMzNS4zIEwzMzUuMywzMzUuMyBaIiBpZD0iU2hhcGUiPjwvcGF0aD4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+',
             ));
         }
     }
@@ -62,7 +65,7 @@ class App
             $markup .= '<div class="container gutter gutter-lg gutter-vertical"><div class="grid"><div class="grid-xs-12">';
 
             foreach ($matchingNotices as $notice) {
-                if (in_array('empty', (array)$notice['options']) && $wp_query->found_posts > 0) {
+                if (in_array('empty', (array) $notice['options']) && $wp_query->found_posts > 0) {
                     continue;
                 }
 
@@ -70,9 +73,9 @@ class App
                         <div class="notice gutter-sm ' . $notice['notice_class'] . '">
                             <div class="grid no-padding grid-table-md grid-va-middle">
                                 <div class="grid-auto text-left-md text-left-lg">
-                                    <p>'. nl2br(strip_tags($notice['notice'], '<a>')) .'</p>
+                                    <p>' . nl2br(strip_tags($notice['notice'], '<a>')) . '</p>
                                 </div>
-                                ' . $this->buttonOutput($notice) .'
+                                ' . $this->buttonOutput($notice) . '
                             </div>
                         </div>
                 ';
@@ -88,12 +91,12 @@ class App
 
     private function buttonOutput($notice)
     {
-        $buttonMarkup = "";
+        $buttonMarkup = '';
 
         if ($notice['notice_show_button'] === true) {
             $buttonMarkup = '
                 <div class="grid-fit-content text-right-md text-right-lg">
-                    <a class="btn btn-primary" href="'.$notice['notice_button_url'].'">'.$notice['notice_button_text'].'</a>
+                    <a class="btn btn-primary" href="' . $notice['notice_button_url'] . '">' . $notice['notice_button_text'] . '</a>
                 </div>
             ';
         }
@@ -186,7 +189,6 @@ class App
     public function fields()
     {
         if (function_exists('acf_add_local_field_group')):
-
             acf_add_local_field_group(array(
                 'key' => 'group_57e2869d5225e',
                 'title' => 'Search notices',
@@ -274,8 +276,7 @@ class App
                                 'choices' => array(
                                     'empty' => 'Only on empty search result',
                                 ),
-                                'default_value' => array(
-                                ),
+                                'default_value' => array(),
                                 'layout' => 'horizontal',
                                 'toggle' => 0,
                                 'return_format' => 'value',
@@ -386,7 +387,6 @@ class App
                 'active' => 1,
                 'description' => '',
             ));
-
         endif;
     }
 }


### PR DESCRIPTION
### Javascript enhancements:

- eslint and prettier replaced with biome.
    - NPM run commands to use:
        - **build** => vite build
        - **build:dev** => vite build --mode development
        - **watch** => vite build --watch --mode development
        - **format** => npx biome format ./source
        - **format:write** => npx biome format ./source --write
        - **lint** => npx biome lint ./source
        - **lint:write** => npx biome lint ./source --write
- All js converted to ts (Although not refactored)
- VS code extensions updated to support biome    
- Applied vite as JS build engine (configured through /vite.config.mjs)
- Removed all references to webpack

### PHP enhancements

- Introduced Mago as formatter and linter (configured through /mago.toml)
    - Composer commands to use:
        - **lint** => vendor/bin/mago lint
        - **fix** => vendor/bin/mago lint --fix --format
        - **format** => vendor/bin/mago fmt
- VS code extensions updated to support Mago
- VS code settings updated to support Mago
- Migrate to wputilservice

### Other
- Add files to .gitignore and build.php

NOTE! Minor fixes to allow code build has been done but no refactoring. Hance certain lint rules has been disabled in
mago.toml temporarily. These should be removed when working on the codebase.
